### PR TITLE
update indgen and predgen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,8 @@ set(SOURCES
   "${PROJECT_SOURCE_DIR}/engines/ic3ng-support/model.cpp"
   "${PROJECT_SOURCE_DIR}/engines/ic3ng-support/support.cpp"
   "${PROJECT_SOURCE_DIR}/engines/ic3ng-support/predload.cpp"
+  "${PROJECT_SOURCE_DIR}/engines/ic3ng-support/predgen.cpp"
+  "${PROJECT_SOURCE_DIR}/engines/ic3ng-support/indgen.cpp"
   "${PROJECT_SOURCE_DIR}/engines/ic3ng.cpp"
   "${PROJECT_SOURCE_DIR}/frontends/btor2_encoder.cpp"
   "${PROJECT_SOURCE_DIR}/frontends/smv_encoder.cpp"

--- a/engines/ic3ng-support/cex_info_map.h
+++ b/engines/ic3ng-support/cex_info_map.h
@@ -21,18 +21,35 @@ struct PerCexInfo {
   PerCexInfo(smt::TermVec && pred) : preds_to_use(pred) {}
 };
 
-struct PerVarInfo {
-  std::unordered_set<smt::Term> vars_noslice_in_cex;
-  std::string vars_noslice_canonical_string;
+struct PerUnslicedVarInfo { // `unsliced` means the variables without `extract`
+  std::unordered_set<smt::Term> vars_in_cex;
+  std::string vars_canonical_string;
+
   unsigned ref_count; // we want to know, if the CTIs are often about a certain vars or not
+                      // this is not used for memory management
+                      // because once a cex is generated, it will not be deleted anyway
 
   bool related_info_populated;
   smt::Term related_trans;
   smt::TermVec preds_w_subset_vars;
   smt::TermVec preds_w_related_vars;
 
-  PerVarInfo(std::unordered_set<smt::Term> && vars, std::string && hashstring):
-    vars_noslice_in_cex(vars), vars_noslice_canonical_string(hashstring), ref_count(0), related_info_populated(false)
+  PerUnslicedVarInfo(std::unordered_set<smt::Term> && vars, const std::string & hashstring) :
+    vars_in_cex(std::move(vars)), vars_canonical_string(hashstring),
+    ref_count(0), related_info_populated(false) {   }
+};
+
+struct PerSlicedVarInfo {
+  std::unordered_set<smt::Term> slicedvars_in_cex;
+  std::string vars_canonical_string;
+  PerUnslicedVarInfo * unsliced_varinfo;
+
+  PerSlicedVarInfo(std::unordered_set<smt::Term> && vars, const std::string & hashstring,
+    PerUnslicedVarInfo * unsliced_varptr
+  ):
+    slicedvars_in_cex(std::move(vars)), vars_canonical_string(hashstring), 
+    unsliced_varinfo(unsliced_varptr)
    {}
 };
+
 

--- a/engines/ic3ng-support/debug.h
+++ b/engines/ic3ng-support/debug.h
@@ -4,6 +4,8 @@
 #ifdef DEBUG_IC3
 #define D(...) logger.log(__VA_ARGS__)
 #define LOGCAT (std::cout)
+// #define DEBUG_IC3_PREDGEN 1
+
 
 #else
 #define  D(...) do{}while(0)

--- a/engines/ic3ng-support/indgen.cpp
+++ b/engines/ic3ng-support/indgen.cpp
@@ -1,0 +1,538 @@
+/*********************                                                  */
+/*! \file indgen.cpp
+** \verbatim
+** Top contributors (to current version of this file):
+**   Hongce Zhang
+** This file is part of the pono project.
+** Copyright (c) 2025 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Inductive generalization
+**/
+
+
+#include "utils/logger.h"
+#include "engines/ic3ng.h"
+#include "engines/ic3ng-support/debug.h"
+#include "utils/container_shortcut.h"
+
+
+namespace pono
+{
+
+
+static size_t TermScoreVar(const smt::Term & t) {
+  // remove NOT
+  auto e = (t->get_op().prim_op == smt::PrimOp::Not ||
+            t->get_op().prim_op == smt::PrimOp::BVNot) ? *(t->begin()): t;
+  // if it is just a variable: 0
+  // otherwise, slice+width
+  unsigned slice = 0;
+  if (e->get_op().prim_op == smt::PrimOp::Extract) {
+    slice = e->get_op().idx0;
+    auto c = *(e->begin());
+    slice += c->get_sort()->get_width();
+  }
+  return slice;
+}
+
+static void SortLemma(smt::TermVec & inout, bool descending) {
+  // we don't want to sort the term themselves
+  // we don't want to invoke TermScore function more than once for a term
+  std::vector<std::pair<size_t,size_t>> complexity_index_pair;
+  size_t idx = 0;
+  for (const auto & t : inout) {
+    complexity_index_pair.push_back({ TermScoreVar(t) ,idx});
+    ++ idx;
+  }
+  // sort in descending order (the `first` is compared first), so term-index with 
+  // the highest score will rank first
+  if(descending) // from greater to smaller
+    std::sort(complexity_index_pair.begin(), complexity_index_pair.end(), std::greater<>());
+  else // from smaller to greater
+    std::sort(complexity_index_pair.begin(), complexity_index_pair.end(), std::less<>());
+  // now map back to termvec
+  smt::TermVec sorted_term;
+  for (const auto & cpl_idx_pair : complexity_index_pair) {
+    sorted_term.push_back(inout.at(cpl_idx_pair.second));
+  }
+  inout.swap(sorted_term); // this is the same as inout = sorted_term, but faster
+} // end of SortLemma
+
+
+#if 0
+// ( ( not(S) /\ F /\ T ) \/ init_prime ) /\ ( cube' )
+//   cube (v[0]=1 /\ v[1]=0 /\ ...)
+void IC3ng::inductive_generalization(unsigned fidx, Model *cex, LCexOrigin origin) {
+
+  auto F = get_frame_formula(fidx);
+  auto T = get_trans_for_vars(cex->get_varset_unslice()); // find the update F for vars in set...
+  auto F_and_T = smart_and<smt::TermVec>({F,T});
+
+
+  smt::TermVec all_conjs = cex->to_expr_conj();
+  // HZ: TODO a better way is to check, if the vars are appearing too often
+  // if so, we extend the predicates
+  // otherwise, we will not use word-level preds
+
+
+  // TODO: sort conjs
+  SortLemma(all_conjs, options_.ic3base_sort_lemma_descending);
+
+
+  auto npred = extend_predicates(cex, all_conjs); // IC3INN
+  //  conjs.erase(conjs.begin()+1);
+  //  TODO: you may need more than 1 round (if not word-level pred used)
+  smt::UnorderedTermSet pred_vars, pred_vars_nxt;
+  for (size_t idx = 0; idx < npred; ++ idx) {
+    smt::get_free_symbols( all_conjs.at(idx), pred_vars );
+  }
+  for (const auto & v : pred_vars)
+    pred_vars_nxt.emplace(ts_.next(v));
+
+
+#ifdef DEBUG_IC3_INDGEN
+  std::cout << "After sorting:\n";
+  unsigned i = 0;
+  for (const auto & e : all_conjs)
+    std::cout << " " << i++ << ": " << e->to_string() << "\n";
+  std::cout << "------------------\n";
+#endif
+
+  assert(!all_conjs.empty());
+  if (all_conjs.size() == 1) { // a short-cut
+    auto cex_expr = smart_not(smart_and(all_conjs));
+    D(3,"[ig] F{} get lemma:{}", fidx+1, cex_expr->to_string());
+    auto lemma = new_lemma(cex_expr, cex, origin, std::move(all_conjs)); // it does not matter whether we have the NOT 
+    add_lemma_to_frame(lemma,fidx+1);
+    return;
+  }
+
+  // Next, if we have more than 1 clause...
+  smt::TermVec allconjs_nxt;
+  std::unordered_map<smt::Term, size_t> conjnxt_to_idx_map; // use this map to identify more easily its index
+  for (size_t idx = 0; idx < all_conjs.size(); ++idx) {
+    allconjs_nxt.push_back(ts_.next(all_conjs.at(idx)));
+    conjnxt_to_idx_map.emplace(allconjs_nxt.back(), idx);
+  }
+  std::vector<bool> conjs_used(all_conjs.size(), false); // initialized: all un-used
+
+  unsigned max_round = options_.ic3ng_indgen_max_round; // default 3
+  if (options_.ic3ng_indgen_multilemma_on_predicates_only && npred == 0)
+    max_round = 1; // if we have no predicates, then just one round
+
+  for (unsigned rnd = 0 ; rnd < max_round; ++ rnd) {
+    // we start from all_conjs, and generate the conjs and conj_nxt for this round
+    smt::TermList conjs_list;
+    smt::TermList conjs_nxt;
+    for (size_t idx = 0; idx < all_conjs.size(); ++idx) {
+      if (!conjs_used[idx]) {
+        conjs_list.push_back(all_conjs.at(idx));
+        conjs_nxt.push_back(allconjs_nxt.at(idx));
+      }
+    }
+    // we need to test here, if the remaining ones are still good enough to block the CTI
+    auto cex_expr = smart_not(smart_and(conjs_list));
+    smt::Term base = 
+      smart_or<smt::TermVec>(
+        {smart_and<smt::TermVec>(  {cex_expr, F_and_T} ) , init_prime_ } );
+    solver_->push();
+    disable_all_labels();
+    bool succ = syntax_analysis::reduce_unsat_core_to_fixedpoint(base, conjs_nxt, solver_);
+    solver_->pop();
+    if (!succ) { // the remaining ones are not enough, we should stop
+      D(3,"[ig] not enough pred remained, skipped @ rnd{}.", rnd);
+      assert(rnd != 0); // you should never fail at the first attempt!
+      break;
+    }
+
+    conjs_list.clear(); // update conjs_list
+    for (const auto & c : conjs_nxt)
+      conjs_list.push_back(all_conjs.at(conjnxt_to_idx_map.at(c)));
+
+    if (conjs_nxt.size() > 1) {
+      solver_->push();
+      disable_all_labels();
+      // syntax_analysis::reduce_unsat_core_linear_rev(base, conjs_nxt, solver_);
+      reduce_unsat_core_linear_backwards(F_and_T, conjs_list, conjs_nxt);
+      solver_->pop();
+    }
+
+    // strategy #2: find those variables in provided lemmas, and try to through them away
+    bool disabled_any = false;
+    for (const auto & cj_nxt : conjs_nxt) {
+      auto to_disable_idx = conjnxt_to_idx_map.at(cj_nxt);
+      if (to_disable_idx < npred) continue; // no need to disable those external preds
+      smt::UnorderedTermSet cj_vars;
+      smt::get_free_symbols(cj_nxt,cj_vars);
+      for (const auto & v : cj_vars)
+        if (pred_vars_nxt.find(v) != pred_vars_nxt.end()) {
+          conjs_used[to_disable_idx] = true;
+          disabled_any = true;
+          break;
+        }
+    }
+
+    // Design Choice here: should we disable all or just one, and which one?
+    // strategy #1: using the last one, but is there a better way?
+    if (!disabled_any) {
+      auto to_disable_idx = conjnxt_to_idx_map.at(conjs_nxt.back());
+      conjs_used[to_disable_idx] = true;
+    }
+
+
+#ifdef DEBUG_IC3_INDGEN
+    std::cout << rnd << " Kept:\n";
+    for (const auto & e : conjs_nxt) {
+      std::cout << conjnxt_to_idx_map.at(e) << " : " << e->to_string() << std::endl;
+      if (conjnxt_to_idx_map.at(e) < npred)
+        std::cout << "Used!\n";
+    }
+    std::cout << "------------------\n";
+#endif
+
+    cex_expr = smart_not(smart_and(conjs_list));
+    D(1,"[ig] F{} get lemma size:{}", fidx+1, conjs_list.size());
+    D(3,"[ig] F{} get lemma:{}", fidx+1, cex_expr->to_string());
+    auto lemma = new_lemma(cex_expr, cex, origin, smt::TermVec(conjs_list.begin(),conjs_list.end()) );
+    add_lemma_to_frame(lemma,fidx+1);
+  } // end for each round
+} // end of inductive_generalization
+#endif
+
+// a helper function : the rev version
+// it goes from the end to the beginning
+void remove_and_move_to_next_backward(smt::TermList & pred_set_prev, smt::TermList::iterator & pred_pos_rev,
+  smt::TermList & pred_set, smt::TermList::iterator & pred_pos,
+  const smt::UnorderedTermSet & unsatcore) {
+
+  assert(pred_set.size() == pred_set_prev.size());
+  assert(pred_pos != pred_set.end());
+  assert(pred_pos_rev != pred_set_prev.end());
+
+  auto pred_iter = pred_set.end(); // pred_pos;
+  auto pred_pos_new = pred_set.end();
+
+  auto pred_iter_prev = pred_set_prev.end();
+  auto pred_pos_new_prev = pred_set_prev.end();
+
+  pred_pos_new--;
+  pred_pos_new_prev--;
+
+  bool reached = false;
+  bool next_pos_found = false;
+
+  while( pred_iter != pred_set.begin() ) {
+    pred_iter--;
+    pred_iter_prev--;
+    
+    if (!reached && pred_iter == pred_pos) {
+      reached = true;
+    }
+    
+    if (unsatcore.find(*pred_iter) == unsatcore.end()) {
+      // assert (reached); OK, this can happen.
+      // it is possible that a previously unremoveable one now is removable
+      // because the pre-set is also changed (it becomes more restrictive
+      // after you remove another one)
+      pred_iter = pred_set.erase(pred_iter);
+      pred_iter_prev = pred_set_prev.erase(pred_iter_prev);
+    } else {
+      if (reached && ! next_pos_found) {
+        pred_pos_new = pred_iter;
+        pred_pos_new ++;
+
+        pred_pos_new_prev = pred_iter_prev;
+        pred_pos_new_prev++;
+
+        next_pos_found = true;
+      }
+    }
+  } // end of while
+
+  assert(reached);
+  if (! next_pos_found) {
+    assert (pred_iter == pred_set.begin());
+    assert (pred_iter_prev == pred_set_prev.begin());
+
+    pred_pos_new = pred_iter;
+    pred_pos_new_prev = pred_iter_prev;
+  }
+  pred_pos = pred_pos_new;
+  pred_pos_rev = pred_pos_new_prev;
+} // remove_and_move_to_next
+
+// 1. check if init /\ (conjs-removed)  is unsat
+// 2. if so, check ( ( not(conjs-removed) /\ F /\ T ) /\ ( conjs-removed )' is unsat?
+void IC3ng::reduce_unsat_core_linear_backwards(const smt::Term & F_and_T,
+  smt::TermList &conjs, smt::TermList & conjs_nxt) {
+  
+  auto to_remove_pos_prev = conjs.end(); // prev means on the predicates with current version of variables
+  auto to_remove_pos_next = conjs_nxt.end(); // next means over the predicates with the next version of variables
+
+  assert(conjs.size() == conjs_nxt.size());
+
+  while(to_remove_pos_prev != conjs.begin()) {
+    to_remove_pos_prev--; // firstly, point to the last one
+    to_remove_pos_next--; // synchronously point to the corresponding one in the next set
+
+    if (conjs.size() == 1) // no need to reduce anymore, if we only have 1 left
+      continue;
+
+    smt::Term term_to_remove = *to_remove_pos_prev;
+    smt::Term term_to_remove_next = *to_remove_pos_next;
+
+    auto pos_after_conj = conjs.erase(to_remove_pos_prev); // let's try to remove it
+    auto pos_after_conj_nxt = conjs_nxt.erase(to_remove_pos_next);
+    // the return value is the pointer to the element after the removed one
+
+    auto cex_expr = smart_not(smart_and(conjs));
+    auto base = smart_or<smt::TermVec>(
+        { smart_and<smt::TermVec>(  {cex_expr, F_and_T} ) , init_prime_ } );
+
+    solver_->push();
+    disable_all_labels();
+    solver_->assert_formula(base);
+    smt::Result r = solver_->check_sat_assuming_list(conjs_nxt);
+
+    to_remove_pos_prev = conjs.insert(pos_after_conj, term_to_remove); // will insert before pos_after_conj
+    to_remove_pos_next = conjs_nxt.insert(pos_after_conj_nxt, term_to_remove_next);
+    if (r.is_sat()) {
+      solver_->pop();
+      continue;
+    } // else { // if unsat, we can remove
+    smt::UnorderedTermSet core_set;
+    solver_->get_unsat_assumptions(core_set);
+    // below function will update assumption_list and to_remove_pos
+    remove_and_move_to_next_backward(conjs, to_remove_pos_prev, conjs_nxt, to_remove_pos_next, core_set);
+    solver_->pop();
+  } // end of while
+}
+
+// ---------------------- BELOW is another method --------------------------- //
+
+// remove from conjs_list those elements that are not in (core1 union core2)
+// and also remove its next state version from conjs_next
+static void update_list_based_on_core(smt::TermList & conjs_list, smt::TermList & conjs_next, 
+  // core1 and core1 are all on current variables
+  const smt::TermList & core1, const smt::TermList & core2)
+{
+  smt::UnorderedTermSet core(core1.begin(), core1.end());
+  for (const auto & t : core2)
+    core.emplace(t);
+
+  for (auto pos = conjs_list.begin(), pos_nxt = conjs_next.begin(); pos != conjs_list.end(); ) {
+    if (core.find(*pos) == core.end()) {
+      // can remove it
+      pos = conjs_list.erase(pos);
+      pos_nxt = conjs_next.erase(pos_nxt);
+    } else {
+      ++ pos; ++pos_nxt;
+    }
+  }
+}
+
+bool IC3ng::ic3_down(smt::TermList & conjs_list, smt::TermList & conjs_next, 
+    const smt::Term & Trans, unsigned fidx,
+    std::unordered_map<smt::Term, size_t> & conjnxt_to_idx_map, smt::TermVec all_conjs_curr) 
+{  // now let's check (1) init /\ conj_list 
+  while(true) {
+    solver_->push();
+    assert_init();
+    auto res = solver_->check_sat_assuming_list(conjs_list);
+    solver_->pop();
+    if (res.is_sat()) { // if sat
+      return false;
+    }
+    // now let's check (2)  F(i) /\ not(conjs_list) /\ Trans /\ conjs_nxt
+    solver_->push();
+    assert_frame(fidx);
+    solver_->assert_formula(smart_not(smart_and(conjs_list)));
+    solver_->assert_formula(Trans);
+    res = solver_->check_sat_assuming_list(conjs_next);
+    if (res.is_unsat()) {
+      // yes, we can remove, 
+      smt::UnorderedTermSet unsatcore_next;
+      solver_->get_unsat_assumptions(unsatcore_next); // unsatcore_next would be a subset of conjs_nxt
+      solver_->pop();
+      // map cores to curr state version
+      smt::TermList unsatcore_curr;
+      for (const auto & t : unsatcore_next) // map to curr
+        unsatcore_curr.push_back(all_conjs_curr.at(conjnxt_to_idx_map.at(t)));
+      // now we need to make sure, this has no intersection with init 
+      // (init /\ the remaining conjs)  should be unsat
+      solver_->push();
+      assert_init();
+      auto init_check = solver_->check_sat_assuming_list(unsatcore_curr);
+      solver_->pop();
+      if (init_check.is_sat()) {
+        // we are removing too many elements
+        // let's fix this problem
+        //      init /\ the remaining conjs /\ all conjs       is still unsat
+        // reduce those in (all conjs)
+        smt::TermList reduced_cube = conjs_list; // make a copy
+        solver_->push();
+        assert_init();
+        for (const auto & t : unsatcore_curr)
+          solver_->assert_formula(t);
+        // reduce the elements in reduced_cube
+        bool is_unsat = syntax_analysis::reduce_unsat_core_to_fixedpoint(solver_true_, reduced_cube, solver_);
+        assert(is_unsat);
+        syntax_analysis::reduce_unsat_core_linear_rev(solver_true_, reduced_cube, solver_);
+        assert(!reduced_cube.empty());
+        solver_->pop();
+        // update conjs_list and conjs_nxt
+        // only keep those in `unsatcore_curr union reduced_cube`
+        update_list_based_on_core(conjs_list, conjs_next, unsatcore_curr, reduced_cube);
+        return true;
+      } // end of 'amending core'
+      // if we don't need amendment, then, we just update
+      // only keep those in `unsatcore_curr`
+      update_list_based_on_core(conjs_list, conjs_next, unsatcore_curr, {});
+      return true;
+    } else {
+      // (2)  F(i) /\ not(conjs_list) /\ Trans /\ conjs_nxt is SAT
+      // then we extract the SAT assignment and update conjs_list and conjs_next
+      for (auto pos = conjs_list.begin(), pos_next = conjs_next.begin();
+          pos != conjs_list.end(); ) {
+        const auto & t = *pos;
+        auto val = solver_->get_value(t);
+        if (extract_bit_from_val(val) != true ) { 
+          // remove this
+          pos = conjs_list.erase(pos);
+          pos_next = conjs_next.erase(pos_next);
+        } else {
+          ++ pos; ++ pos_next;
+        }
+      } // this is q = q |_| s
+      solver_->pop();
+    } // and then try again
+  } // end of while (true)
+} // end of ic3_down
+
+
+// ( ( not(S) /\ F /\ T ) \/ init_prime ) /\ ( cube' )
+//   cube (v[0]=1 /\ v[1]=0 /\ ...)
+void IC3ng::inductive_generalization_mic(unsigned fidx, Model *cex, LCexOrigin origin) {
+
+  // auto F = get_frame_formula(fidx);
+  auto Trans = get_trans_for_vars(cex->get_varset_unslice()); // find the update F for vars in set...
+  // auto F_and_T = smart_and<smt::TermVec>({F,T});
+
+
+  smt::TermVec all_conjs = cex->to_expr_conj();
+  // HZ: TODO a better way is to check, if the vars are appearing too often
+  // if so, we extend the predicates
+  // otherwise, we will not use word-level preds
+
+
+  // TODO: sort conjs
+  SortLemma(all_conjs, options_.ic3base_sort_lemma_descending);
+
+
+  auto npred = extend_predicates(cex, all_conjs); // IC3INN
+
+#ifdef DEBUG_IC3_INDGEN
+  std::cout << "# pred: " << npred << std::endl;
+  std::cout << "After sorting:\n";
+  unsigned i = 0;
+  for (const auto & e : all_conjs)
+    std::cout << " " << i++ << ": " << e->to_string() << "\n";
+  std::cout << "------------------\n";
+#endif
+  
+
+  assert(!all_conjs.empty());
+  if (all_conjs.size() == 1) { // a short-cut
+    auto cex_expr = smart_not(smart_and(all_conjs));
+    D(3,"[ig] F{} get lemma:{}", fidx+1, cex_expr->to_string());
+    auto lemma = new_lemma(cex_expr, cex, origin, std::move(all_conjs)); // it does not matter whether we have the NOT 
+    add_lemma_to_frame(lemma,fidx+1);
+    return;
+  }
+
+  // Next, if we have more than 1 clause...
+  smt::TermVec allconjs_nxt;
+  std::unordered_map<smt::Term, size_t> conjnxt_to_idx_map; // use this map to identify more easily its index
+  for (size_t idx = 0; idx < all_conjs.size(); ++idx) {
+    allconjs_nxt.push_back(ts_.next(all_conjs.at(idx)));
+    conjnxt_to_idx_map.emplace(allconjs_nxt.back(), idx);
+  }
+  // we start from all_conjs, and generate the conjs and conj_nxt for this round
+  smt::TermList conjs_list;
+  smt::TermList conjs_nxt;
+  for (size_t idx = 0; idx < all_conjs.size(); ++idx) {
+    //if (!conjs_used[idx]) {
+      conjs_list.push_back(all_conjs.at(idx));
+      conjs_nxt.push_back(allconjs_nxt.at(idx));
+    //}
+  }
+  // from the last element, try to remove from conjs_list and conjs_nxt and check
+  // (1) init /\ conj_list             (is unsat)   (disable all)
+  // (2) F(i) /\ not(conjs_list) /\ Trans /\ conjs_nxt   (is unsat)
+  //          if unsat, use UNSAT core to further reduce and return
+  //          if not, extract sat-value of elements in conjs_list, if the literal is not true, then remove it
+  //             and try again
+  //     Use a `keep` to record those you cannot remove anyway
+
+  auto to_remove_pos_curr_term = conjs_list.end(); // prev means on the predicates with current version of variables
+  auto to_remove_pos_next_term = conjs_nxt.end(); // next means over the predicates with the next version of variables
+
+  while (to_remove_pos_curr_term != conjs_list.begin()) {
+    to_remove_pos_curr_term --; to_remove_pos_next_term --;
+
+    if (conjs_list.size() == 1)
+      continue; // no need to reduce anymore, if we only have 1 left
+
+    smt::Term term_to_remove_curr = *to_remove_pos_curr_term;
+    smt::Term term_to_remove_next = *to_remove_pos_next_term;
+
+    auto pos_after_conj_curr = conjs_list.erase(to_remove_pos_curr_term); // let's try to remove it
+    auto pos_after_conj_next = conjs_nxt.erase(to_remove_pos_next_term);
+    
+    auto conjs_list_copy = conjs_list;
+    auto conjs_nxt_copy  = conjs_nxt;
+
+    bool res = ic3_down(conjs_list_copy, conjs_nxt_copy, Trans, fidx, conjnxt_to_idx_map, all_conjs);
+
+    to_remove_pos_curr_term = conjs_list.insert(pos_after_conj_curr, term_to_remove_curr); // will insert before pos_after_conj
+    to_remove_pos_next_term = conjs_nxt.insert(pos_after_conj_next, term_to_remove_next);
+    if (!res) {
+      continue;
+    } else {
+      // update conjs_list, conjs_nxt_copy, and to_remove_pos_curr_term, term_to_remove_next
+      assert(conjs_list_copy.size() == conjs_nxt_copy.size());
+      smt::UnorderedTermSet remaining(conjs_nxt_copy.begin(), conjs_nxt_copy.end());
+      remove_and_move_to_next_backward(conjs_list, to_remove_pos_curr_term, conjs_nxt, to_remove_pos_next_term, remaining);
+      }
+  } // end of while (going backwards through the constraints)
+
+#ifdef DEBUG_IC3_INDGEN
+  std::cout << " Kept:\n";
+  for (const auto & e : conjs_nxt) {
+    std::cout << conjnxt_to_idx_map.at(e) << " : " << e->to_string() << std::endl;
+    if (conjnxt_to_idx_map.at(e) < npred)
+      std::cout << "Used!\n";
+  }
+  std::cout << "------------------\n";
+
+  for (const auto & e : conjs_nxt) {
+    if (conjnxt_to_idx_map.at(e) < npred) {
+      std::cout << "[IG] Pred is used!\n";
+      break;
+    }
+  }
+#endif
+
+  auto cex_expr = smart_not(smart_and(conjs_list));
+  D(1,"[ig] F{} get lemma size:{}", fidx+1, conjs_list.size());
+  D(3,"[ig] F{} get lemma:{}", fidx+1, cex_expr->to_string());
+  auto lemma = new_lemma(cex_expr, cex, origin, smt::TermVec(conjs_list.begin(),conjs_list.end()) );
+  add_lemma_to_frame(lemma,fidx+1);
+    
+} // end of inductive_generalization_mic
+
+
+} // end of namespace pono

--- a/engines/ic3ng-support/lemma.cpp
+++ b/engines/ic3ng-support/lemma.cpp
@@ -13,7 +13,9 @@ ModelLemmaManager::~ModelLemmaManager() {
     delete lp;
   for (auto mp : cube_allocation_pool)
     delete mp;
-  for (auto vp : cube_var_info_allocation_pool)
+  for (auto vp : cube_slicedvar_info_allocation_pool)
+    delete vp.second;
+  for (auto vp : cube_unslicevar_info_allocation_pool)
     delete vp.second;
 }
 
@@ -23,32 +25,46 @@ ModelLemmaManager::~ModelLemmaManager() {
 // }
 
 
-Model * ModelLemmaManager::new_model(const std::unordered_map <smt::Term,std::vector<std::pair<int,int>>> & varset) {
-  std::unordered_set<smt::Term> varset_noslice;
-  Model::compute_varset_noslice(varset, varset_noslice);
-  std::string hashstring = Model::compute_vars_noslice_canonical_string(varset_noslice);
-  auto pos = cube_var_info_allocation_pool.find(hashstring);
-  if (pos == cube_var_info_allocation_pool.end()) {
-    auto res = cube_var_info_allocation_pool.emplace(
-      hashstring,
-      new PerVarInfo(std::move(varset_noslice),std::move(hashstring)));
+Model * ModelLemmaManager::new_model(
+  smt::UnorderedTermSet && slicedvarset, 
+  smt::UnorderedTermSet && unslicedvarset,
+  smt::TermVec && eqs) {
+  std::string sliced_hashstring = Model::compute_vars_canonical_string(slicedvarset);
+  auto pos = cube_slicedvar_info_allocation_pool.find(sliced_hashstring);
+  if (pos == cube_slicedvar_info_allocation_pool.end()) {
+    // try to find unsliced var
+    std::string unsliced_hashstring = Model::compute_vars_canonical_string(unslicedvarset);
+    auto pos_unsliced = cube_unslicevar_info_allocation_pool.find(unsliced_hashstring);
+    if (pos_unsliced == cube_unslicevar_info_allocation_pool.end()) {
+      // build unsliced var first;
+      auto res = cube_unslicevar_info_allocation_pool.emplace(unsliced_hashstring,
+        new PerUnslicedVarInfo(std::move(unslicedvarset), unsliced_hashstring));
+      assert(res.second);
+      pos_unsliced = res.first;
+    }
+
+    auto res = cube_slicedvar_info_allocation_pool.emplace(
+      sliced_hashstring,
+      new PerSlicedVarInfo(std::move(slicedvarset),sliced_hashstring, pos_unsliced->second));
     assert(res.second); // insertion must be successful
     pos = res.first;
   }
 
-  cube_allocation_pool.push_back(new Model(solver(),varset, pos->second));
+  cube_allocation_pool.push_back(new Model(std::move(eqs), pos->second));
   return cube_allocation_pool.back();
 }
 
-void ModelLemmaManager::register_new_model(Model * m) {
-  assert (m);
-  cube_allocation_pool.push_back(m);
-}
+// void ModelLemmaManager::register_new_model(Model * m) {
+//   assert (m);
+//   cube_allocation_pool.push_back(m);
+// }
 
 
 Lemma * ModelLemmaManager::new_lemma(
-  const smt::Term & expr, Model * cex, LCexOrigin origin) {
-  lemma_allocation_pool.push_back(new Lemma(expr, cex, origin));
+  const smt::Term & expr, Model * cex, LCexOrigin origin, smt::TermVec && cube) {
+  if (origin.is_must_block() || origin.is_may_block())
+    assert(!cube.empty()); // this cannot be the default empty
+  lemma_allocation_pool.push_back(new Lemma(expr, std::move(cube), cex, origin));
   return lemma_allocation_pool.back();
 }
 

--- a/engines/ic3ng-support/lemma.h
+++ b/engines/ic3ng-support/lemma.h
@@ -9,7 +9,7 @@ namespace pono
     
   struct LCexOrigin{ // the origin of a model (and therefore its lemma to block)
     public:
-      enum CexType {MUST_BLOCK, MAY_BLOCK, ORIGIN_FROM_INIT, PROPERTY, CONSTRAINT} cex_type;
+      enum CexType {MUST_BLOCK, MAY_BLOCK, ORIGIN_FROM_INIT, PROPERTY, CONSTRAINT, SIDE_LOAD} cex_type;
     private:
       unsigned step_to_fail; // only matters for MUST_BLOCK
     public:
@@ -19,6 +19,7 @@ namespace pono
       bool inline is_may_block() const { return cex_type == MAY_BLOCK; }
       bool inline is_the_property() const { return cex_type == PROPERTY; }
       bool inline is_constraint() const { return cex_type == CONSTRAINT; }
+      bool inline is_side_load() const { return cex_type == SIDE_LOAD; }
       unsigned inline dist_to_fail() const { return step_to_fail; }
       CexType inline get_type() const { return cex_type;} 
       LCexOrigin to_prior_frame() const { 
@@ -31,16 +32,19 @@ namespace pono
       static LCexOrigin FromInit() { return LCexOrigin(ORIGIN_FROM_INIT, 0); }
       static LCexOrigin FromProperty() { return LCexOrigin(PROPERTY, 0); }
       static LCexOrigin FromConstraint() { return LCexOrigin(CONSTRAINT, 0); }
+      static LCexOrigin FromSideLoad() { return LCexOrigin(SIDE_LOAD, 0); }
   };
 
     // the lemma on a frame
   class Lemma {
     public:
     
-    Lemma(const smt::Term & expr, Model * cex, LCexOrigin origin) : expr_(expr), 
+    Lemma(const smt::Term & expr, smt::TermVec && cube, Model * cex, LCexOrigin origin) : 
+      expr_(expr), cube_(std::move(cube)), 
       cex_(cex),  origin_(origin) { }
     
     inline smt::Term  expr() const { return expr_; }
+    inline const smt::TermVec & cube() const { return cube_; }
     inline Model *  cex() const { return cex_; }
     inline std::string to_string() const { return expr()->to_string(); }
     inline LCexOrigin origin() const { return origin_; }
@@ -52,13 +56,21 @@ namespace pono
 
     // bool subsume_by_frame(unsigned fidx, LemmaPDRInterface & pdr);
 
-    static std::string origin_to_string(LCexOrigin o) ;
-    std::string dump_expr() const;
-    std::string dump_cex() const;
+    // static std::string origin_to_string(LCexOrigin o) ;
+    // std::string dump_expr() const;
+    // std::string dump_cex() const;
 
     protected:
     // the expression : for btor
+    // the expr should be not(Conj(var==val)) for var,val in cube
     smt::Term expr_;
+
+    // cube_ is just a vector of var==val
+    smt::TermVec cube_;
+
+    // a map: term->term, var == val
+    // cube_t cube_;
+
     // the cex it blocks
     Model*  cex_;
     // status tracking
@@ -80,19 +92,25 @@ public:
   virtual smt::SmtSolver & solver() = 0;
 
 protected:
+  // [deprecated]
   // Model * new_model();
-  void register_new_model(Model *);
-  Model * new_model(const std::unordered_map <smt::Term,std::vector<std::pair<int,int>>> & varset);
+  // void register_new_model(Model *);
+
+  // by default, move in the args
+  Model * new_model(smt::UnorderedTermSet && slicedvarset, 
+                    smt::UnorderedTermSet && unslicedvarset,
+                    smt::TermVec && eqs);
   // Model * new_model_replace_var(
   //   const std::unordered_map <smt::Term,std::vector<std::pair<int,int>>> & varset,
   //   const std::unordered_map<smt::Term, smt::Term> & varmap );
 
   Lemma * new_lemma(
-    const smt::Term & expr, Model * cex, LCexOrigin origin);
+    const smt::Term & expr, Model * cex, LCexOrigin origin, smt::TermVec && cube = {});
     
   std::vector<Lemma *> lemma_allocation_pool;
   std::vector<Model *> cube_allocation_pool;
-  std::unordered_map<std::string, PerVarInfo *> cube_var_info_allocation_pool;
+  std::unordered_map<std::string, PerSlicedVarInfo *> cube_slicedvar_info_allocation_pool;
+  std::unordered_map<std::string, PerUnslicedVarInfo *> cube_unslicevar_info_allocation_pool;
 };
 
 } // namespace pono

--- a/engines/ic3ng-support/model.cpp
+++ b/engines/ic3ng-support/model.cpp
@@ -9,43 +9,14 @@ namespace pono {
 
 std::string Model::to_string() const {
   std::string ret;
-  for (const auto & var_val_pair : cube) {
-    if (var_val_pair.first->is_symbol())
-      ret += " " + var_val_pair.first->to_string() + "=" + var_val_pair.second->to_string();
-    else {
-      auto op = var_val_pair.first->get_op();
-      assert(op.prim_op == smt::Extract);
-      auto child = *(var_val_pair.first->begin());
-      auto left = op.idx0, right = op.idx1;
-      ret += " " + child->to_string() + "["+ std::to_string(left) + ":"+  std::to_string(right) +"]=" + var_val_pair.second->to_string();
-    }
+  for (const auto & eq : conjs) {
+    ret += eq->to_string() + " /\\ ";
   }
   return ret;
 }
 
-std::string Model::get_var_canonical_string() const {
-  std::vector<std::string> varnames;
-  for (const auto & var_val_pair : cube) {
-    if (var_val_pair.first->is_symbol())
-      varnames.push_back(var_val_pair.first->to_string());
-    else {
-      auto op = var_val_pair.first->get_op();
-      assert(op.prim_op == smt::Extract);
-      auto child = *(var_val_pair.first->begin());
-      auto left = op.idx0, right = op.idx1;
-      assert(child->is_symbol());
-      varnames.push_back(child->to_string()+"["+ std::to_string(left) + ":"+  std::to_string(right) +"]");
-    }
-  }
-  // sort
-  std::sort(varnames.begin(),varnames.end());
-  std::string ret;
-  for(const auto & n : varnames)
-    ret += n + DELIM;
-  return ret;
-}
 
-std::string Model::compute_vars_noslice_canonical_string(const std::unordered_set<smt::Term> & varset) {
+std::string Model::compute_vars_canonical_string(const std::unordered_set<smt::Term> & varset) {
   std::vector<std::string> varnames;
   for (const auto &v : varset)
     varnames.push_back(v->to_string());
@@ -56,26 +27,6 @@ std::string Model::compute_vars_noslice_canonical_string(const std::unordered_se
   return ret;
 }
 
-void Model::get_varset(std::unordered_set<smt::Term> & varset) const {
-  for (const auto & var_val_pair : cube)
-    varset.emplace(var_val_pair.first);
-}
-
-void Model::compute_varset_noslice(const std::unordered_map <smt::Term,std::vector<std::pair<int,int>>> & varset_slice,
-  std::unordered_set<smt::Term> & varset) 
-{
-  for (const auto & var_bits_pair : varset_slice) {
-    varset.emplace(var_bits_pair.first);
-  }
-} // end of get_varset_noslice
-
-
-void Model::to_expr_conj(smt::SmtSolver & btor_solver_, smt::TermVec & out) const {
-  for (const auto & var_val_pair : cube) {
-    auto eq = btor_solver_->make_term(smt::Equal, var_val_pair.first, var_val_pair.second);
-    out.push_back(eq);
-  }
-}
 
 smt::Term Model::to_expr(smt::SmtSolver & btor_solver_) {
   if (expr_cached_ != nullptr)
@@ -86,8 +37,8 @@ smt::Term Model::to_expr(smt::SmtSolver & btor_solver_) {
 
 smt::Term Model::_to_expr(smt::SmtSolver & solver_) {
   smt::Term ret;
-  for (const auto & var_val_pair : cube) {
-    auto eq = solver_->make_term(smt::Equal, var_val_pair.first, var_val_pair.second);
+  assert(!conjs.empty());
+  for (const auto & eq : conjs) {
     if (ret)
       ret = solver_->make_term(smt::And, eq, ret);
     else
@@ -95,26 +46,6 @@ smt::Term Model::_to_expr(smt::SmtSolver & solver_) {
   } 
   return ret;
 }
-
-Model::Model(smt::SmtSolver & solver_,
-  const std::unordered_map <smt::Term,std::vector<std::pair<int,int>>> & varset_slice, 
-  PerVarInfo * var_info_ptr) : var_info_(var_info_ptr)
-{
-  var_info_ptr->ref_count++;
-  for (const auto & v_slice : varset_slice) {
-    const auto & var = v_slice.first;
-    auto val = solver_->get_value(var);
-    for(const auto & slice : v_slice.second) {
-      assert(slice.first>=slice.second);
-      for (unsigned idx = slice.second; idx <= slice.first; ++ idx) {
-        auto slice_var = solver_->make_term(smt::Op(smt::Extract,idx,idx), var);
-        auto slice_val = solver_->make_term(smt::Op(smt::Extract,idx,idx), val);
-        cube.emplace(slice_var,slice_val);
-      }
-    }
-  }
-} // end of constructor
-
 
 std::ostream & operator<< (std::ostream & os, const Model & m) { return (os << m.to_string()); }
 

--- a/engines/ic3ng-support/model.h
+++ b/engines/ic3ng-support/model.h
@@ -18,14 +18,10 @@ struct ic3_rel_ind_check_result{
 
 
 // NOTE: the vars here could be (_ extract ...)
-typedef std::unordered_map<smt::Term, smt::Term> cube_t;
 struct Model {
 
-  static std::string compute_vars_noslice_canonical_string(
+  static std::string compute_vars_canonical_string(
     const std::unordered_set<smt::Term> & varset);
-  static void compute_varset_noslice(
-    const std::unordered_map <smt::Term,std::vector<std::pair<int,int>>> & varset_slice,
-    std::unordered_set<smt::Term> & varset);  // will remove (_ extract )
 
 private: 
   // none cache version, usually
@@ -37,26 +33,26 @@ private:
 public:
   // the following use cache, NOTE: it does not contain NOT!!!
   smt::Term to_expr(smt::SmtSolver & btor_solver_);
-  void to_expr_conj(smt::SmtSolver & btor_solver_, smt::TermVec & out) const;
+  const smt::TermVec & to_expr_conj() const { return conjs; }
   std::string to_string() const;
   
   // these are pre-computed and stored in var_info_
-  std::string get_var_noslice_canonical_string() const { return var_info_->vars_noslice_canonical_string; }
-  const std::unordered_set<smt::Term> & get_varset_noslice() const {  return var_info_->vars_noslice_in_cex; }
+  std::string get_var_canonical_string() const { return var_info_->vars_canonical_string; }
+  const std::unordered_set<smt::Term> & get_varset_sliced() const {  return var_info_->slicedvars_in_cex; }
+  const std::unordered_set<smt::Term> & get_varset_unslice () const { 
+    return var_info_->unsliced_varinfo->vars_in_cex;
+  }
 
-  // these are computed
-  std::string get_var_canonical_string() const;
-  void get_varset(std::unordered_set<smt::Term> & varset) const;
 
   // constructors
   // Model() : expr_cached_(NULL) {}
-  Model(const Model &m) : cube(m.cube), expr_cached_(m.expr_cached_) {}
-  // from get value from a solver
-  Model(smt::SmtSolver & solver_, 
-    const std::unordered_map <smt::Term,std::vector<std::pair<int,int>>> & varset_slice,
-    PerVarInfo * var_info_ptr);
+  // Model(const Model &m) : conjs(m.conjs), expr_cached_(m.expr_cached_) {}
+  // by default, move var_val_map to avoid copy
+  Model(smt::TermVec && eqs, 
+    PerSlicedVarInfo * var_info_ptr) : conjs(eqs) , var_info_(var_info_ptr) { var_info_ptr->unsliced_varinfo->ref_count++; }
   
-  PerVarInfo * get_per_var_info() const { return var_info_; }
+  PerSlicedVarInfo * get_per_slicedvar_info() const { return var_info_; }
+  PerUnslicedVarInfo * get_per_unslicedvar_info() const { return var_info_->unsliced_varinfo; }
   // Model(smt::SmtSolver & solver_, 
   //   const std::unordered_map <smt::Term,std::vector<std::pair<int,int>>> & varset_slice, // extract using these vars
   //   const std::unordered_map<smt::Term, smt::Term> & varmap // but use the map in here for the vars
@@ -67,11 +63,10 @@ public:
   //                                      // if v is a var, erase all containing the var
 
 protected:
-  cube_t cube;
+  smt::TermVec conjs;
   // cache expr result
   smt::Term expr_cached_;
-  PerVarInfo * var_info_;
-
+  PerSlicedVarInfo * var_info_;
 };
 
 std::ostream & operator<< (std::ostream & os, const Model & m);

--- a/engines/ic3ng-support/predgen.cpp
+++ b/engines/ic3ng-support/predgen.cpp
@@ -1,0 +1,181 @@
+/*********************                                                  */
+/*! \file predgen.cpp
+** \verbatim
+** Top contributors (to current version of this file):
+**   Hongce Zhang
+** This file is part of the pono project.
+** Copyright (c) 2025 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Predecessor generalization using UNSAT core-based method
+**/
+
+
+
+#include "engines/ic3ng.h"
+#include "engines/ic3ng-support/debug.h"
+#include "utils/container_shortcut.h"
+
+
+namespace pono
+{
+  
+static size_t TermScore(const smt::Term & t) {
+  auto e = (t->get_op().prim_op == smt::PrimOp::Not ||
+            t->get_op().prim_op == smt::PrimOp::BVNot) ? *(t->begin()): t;
+  unsigned slice = 0;
+  if (e->get_op().prim_op == smt::PrimOp::Extract) {
+    slice = e->get_op().idx0;
+    auto c = *(e->begin());
+    slice += c->get_sort()->get_width();
+  }
+  return slice;
+}
+
+void IC3ng::SortCube(std::vector<std::pair<smt::Term, smt::Term>> & inout, bool descending) {
+  // we don't want to sort the term themselves
+  // we don't want to invoke TermScore function more than once for a term
+  std::vector<std::pair<size_t,size_t>> complexity_index_pair;
+  size_t idx = 0;
+  for (const auto & t : inout) { /* score: slice + width */
+    complexity_index_pair.push_back({ TermScore(t.first) ,idx++});
+  }
+
+  // HZ: it seems that ascending sorting will put lower bits first
+
+  //  0: ((_ extract 0 0) x)
+  //  1: ((_ extract 2 2) x)
+  // ....
+
+#ifdef DEBUG_IC3_PREDGEN
+  std::cout << "Before sorting cube:\n";
+  unsigned i = 0;
+  for (const auto & e : inout)
+    std::cout << " " << i++ << ": " << e.first->to_string() << " = " << e.second->to_string() << "\n";
+  std::cout << "------------------\n";
+#endif
+
+  // sort in descending order (the `first` is compared first), so term-index with 
+  // the highest score will rank first
+  if(descending) // from greater to smaller
+    std::sort(complexity_index_pair.begin(), complexity_index_pair.end(), std::greater<>());
+  else // from smaller to greater
+    std::sort(complexity_index_pair.begin(), complexity_index_pair.end(), std::less<>());
+    
+
+  // now map back to termvec
+  std::vector<std::pair<smt::Term, smt::Term>> sorted_term;
+  for (const auto & cpl_idx_pair : complexity_index_pair)
+    sorted_term.push_back(inout.at(cpl_idx_pair.second));
+  
+  inout.swap(sorted_term); // this is the same as inout = sorted_term, but faster
+} // end of SortCube
+
+
+// reduce predecessor by unsat core reduction
+void IC3ng::get_min_pred(
+  const smt::Term &bad_next, /* bad (over current version of variables) */
+  unsigned prevFidx, // fidx
+  smt::UnorderedTermSet & slicedvars,
+  smt::UnorderedTermSet & noslicevars,
+  smt::TermVec & eqs)
+{ // starting from vars in constraints
+  smt::UnorderedTermSet varset = vars_in_constraints_;
+  smt::get_free_symbols(bad_next, varset);
+
+  std::vector<std::pair<smt::Term, smt::Term>> sliced_pairs;
+  std::vector<std::pair<smt::Term, smt::Term>> sliced_pairs_input;
+  for (const auto & v : varset) {
+    // if it is inputvar, put in sliced_pairs, ow. sliced_pairs_input
+    auto & vec = actual_statevars_.find(v) == actual_statevars_.end() ? sliced_pairs_input : sliced_pairs;
+    auto val = solver_->get_value(v);
+    auto sk = v->get_sort()->get_sort_kind();
+    assert(sk == smt::BV || sk == smt::BOOL);
+    if ( sk == smt::BV ) {
+      auto width = v->get_sort()->get_width();
+      if (width > 1) {
+        for (unsigned idx = 0; idx < width; ++idx) {
+          auto sliced_var = solver_->make_term(smt::Op(smt::Extract, idx, idx), v);
+          auto sliced_val = solver_->make_term(smt::Op(smt::Extract, idx, idx), val);
+          vec.push_back(std::make_pair(sliced_var, sliced_val ));
+        }
+        continue; // next variable
+      } // else
+    } // else
+    vec.push_back(std::make_pair(v, val));
+  } // end for each var
+  solver_->pop(); // old values are no longer needed
+  SortCube(sliced_pairs, false);
+  smt::TermList slice_pair_to_reduce;
+  for (const auto & v_val : sliced_pairs)
+    slice_pair_to_reduce.push_back(solver_->make_term(smt::Equal, v_val.first, v_val.second));
+  for (const auto & v_val : sliced_pairs_input)
+   slice_pair_to_reduce.push_back(solver_->make_term(smt::Equal, v_val.first, v_val.second));
+  
+  // build F/\ not(bad)
+  solver_->push();
+  // assert_frame(prevFidx);
+  disable_all_labels();
+  // let's try if s /\ i /\ i' /\ not(bad /\ cons /\ cons' ) work
+  auto not_bad = smart_not(smart_and(smt::TermVec({bad_next, all_constraints_})));
+  auto res = syntax_analysis::reduce_unsat_core_to_fixedpoint(not_bad, slice_pair_to_reduce, solver_);
+  assert(res); // must be unsat
+  // we don't even need to push pop twice...
+  assert(!slice_pair_to_reduce.empty());
+  syntax_analysis::reduce_unsat_core_linear_rev(not_bad, slice_pair_to_reduce, solver_);
+  assert(!slice_pair_to_reduce.empty());
+  solver_->pop();
+
+  // finally, if no assumptions, remove all inputs
+  for (const auto & eq : slice_pair_to_reduce) {
+    smt::Term slice_symb;
+    smt::Term symb;
+    if(eq->get_op().prim_op == smt::PrimOp::Equal) {
+      auto lhs = *(eq->begin());
+      auto rhs = *(++(eq->begin()));
+      auto noslice_lhs = (lhs->get_op().prim_op == smt::PrimOp::Extract) ? *(lhs->begin()) : lhs;
+      auto noslice_rhs = (rhs->get_op().prim_op == smt::PrimOp::Extract) ? *(rhs->begin()) : rhs;
+      assert(noslice_lhs->is_symbol() || noslice_rhs->is_symbol());
+      symb = noslice_lhs->is_symbol() ? noslice_lhs : noslice_rhs;
+      slice_symb = noslice_lhs->is_symbol() ? lhs : rhs;
+    } else if (eq->get_op().prim_op == smt::PrimOp::Not || eq->get_op().prim_op == smt::PrimOp::BVNot) {
+      slice_symb = symb = *(eq->begin());
+      symb = (symb->get_op().prim_op == smt::PrimOp::Extract) ? *(symb->begin()) : symb;
+      assert(symb->is_symbol());
+    } else {
+      slice_symb = eq;
+      symb = (slice_symb->get_op().prim_op == smt::PrimOp::Extract) ? *(slice_symb->begin()) : slice_symb;
+      assert(symb->is_symbol());
+    }
+    if(!ts_.is_curr_var(symb))
+      continue; // definitely remove 
+
+    // I doubt if we need this, rIC3 is not using input
+    // But I don't understand why it is OKAY to do so 
+    // if you find INV CHECK/ CEX CHECK failure
+    // you might use !has_assumptions in the following if-condition
+  
+    if (  /* !has_assumptions && */ actual_statevars_.find(symb) == actual_statevars_.end() )
+      continue; // if no assumptions and symb is actually an input, then remove it
+    slicedvars.insert(slice_symb);
+    noslicevars.insert(symb);
+    eqs.push_back(eq);
+  }
+  assert(!slicedvars.empty());
+  assert(!noslicevars.empty());
+  assert(!eqs.empty());
+
+
+#ifdef DEBUG_IC3_PREDGEN
+  std::cout << "After sorting cube:\n";
+  unsigned i = 0;
+  for (const auto & eq : eqs) {
+    std::cout << " " << i++ << ": " << eq->to_string() << "\n";
+  }
+  std::cout << "------------------\n";
+#endif
+} // end of get_min_pred
+
+} // end of namespace predgen

--- a/engines/ic3ng-support/predload.cpp
+++ b/engines/ic3ng-support/predload.cpp
@@ -3,12 +3,15 @@
 #include <fstream>
 
 #include "smt-switch/smtlib_reader.h"
+#include "utils/logger.h"
+#include "smt-switch/logging_solver.h"
 
 namespace pono {
 
 void IC3ng::set_helper_term_predicates(const smt::TermVec & preds) {
 
   solver_->push();
+  disable_all_labels();
     for (const auto & p : preds) {
       if (!(p->get_sort()->get_sort_kind() == smt::SortKind::BOOL ||
           (p->get_sort()->get_sort_kind() == smt::SortKind::BV && 
@@ -29,6 +32,82 @@ void IC3ng::set_helper_term_predicates(const smt::TermVec & preds) {
   solver_->pop();
 
 }
+
+void IC3ng::set_helper_term_clauses(const smt::TermVec & clauses) {
+  // Store validated clauses
+  
+  logger.log(1, "Starting to validate {} external clauses", clauses.size());
+  
+  for (const auto & clause : clauses) {
+    // check type
+    // HZ: some SMT solvers (e.g. Boolector), does not distinguish 
+    // Bool vs. BV of width 1
+    if ( (clause->get_sort()->get_sort_kind() != smt::SortKind::BOOL) &&
+         !(clause->get_sort()->get_sort_kind() == smt::SortKind::BV &&
+           clause->get_sort()->get_width() == 1 )) {
+      logger.log(2, "Clause {} is not boolean type, skipping", clause);
+      continue;
+    }
+
+    // check init =>  c? 
+    // HZ: the clause we load should contain a "NOT" itself
+    solver_->push();
+    disable_all_labels();
+    solver_->assert_formula(ts_.init());
+    solver_->assert_formula(smart_not(clause));
+    auto r = solver_->check_sat();
+    solver_->pop();
+    if (!r.is_unsat()) {
+      logger.log(2, "Clause {} does not cover initial states, skipping", clause);
+      continue;
+    } // HZ: it must be unsat
+
+    // check:  init & T => clause' ?
+    // HZ: no need to have clause in the previous frame
+    //     because init => clause
+    solver_->push();
+    disable_all_labels();
+    solver_->assert_formula(ts_.init());
+    solver_->assert_formula(ts_.trans());
+    smt::Term next_clause = ts_.next(clause);
+    solver_->assert_formula(smart_not(next_clause));
+    r = solver_->check_sat();
+    solver_->pop();
+
+    if (r.is_unsat()) {
+      // clause is inductive
+      loaded_clauses_.push_back(clause);
+      logger.log(2, "Added valid clause: {}", clause);
+
+      // if frames is not empty, add clause to F₀
+      if (!frames.empty()) {
+        // Create new lemma, marked as FromSideLoad source
+        auto lemma = new_lemma(clause, 
+                              nullptr,  // External clauses have no counterexamples
+                              LCexOrigin::FromSideLoad());
+        
+        logger.log(1, "Adding clause to initial frame: {}", clause->to_string());
+        // add to F1 // 0 is for init, it should be on F1
+        add_lemma_to_frame(lemma, 1); 
+        
+        // HZ: I don't see the reason for doing this. So I remove it.
+        // assert it as a valid invariant to solver
+        // solver_->assert_formula(clause);
+      } else {
+        // HZ: I think you may want to throw an exception
+        // because normally this should not happen 
+        throw PonoException("Frames not initialized yet, clause will be stored in loaded_clauses_");
+      }
+    } else {
+      logger.log(2, "Clause {} fails to cover reachable states at F1, skipping", clause);
+    }
+  } // end of for each clause
+  
+  logger.log(1, 
+             "Loaded {} valid clauses out of {} total clauses",
+             loaded_clauses_.size(),
+             clauses.size());
+} // end of IC3ng::set_helper_term_clauses
 
 // if  A is a subset (or equal to ) B, returns true
 bool static is_subset(const smt::UnorderedTermSet & A, const smt::UnorderedTermSet & B) {
@@ -52,12 +131,12 @@ bool static has_intersection(const smt::UnorderedTermSet & a, const smt::Unorder
 // s ==00 ->  a > b   a == b a>=b 
 unsigned IC3ng::extend_predicates(Model *cex, smt::TermVec & conj_inout) {
   auto model_info_pos = model_info_map_.find(cex);
-  PerVarInfo * var_info = cex->get_per_var_info();  
+  PerUnslicedVarInfo * var_info = cex->get_per_unslicedvar_info();
 
   if (model_info_pos == model_info_map_.end()) {
     if (!var_info->related_info_populated) {
       const smt::UnorderedTermSet & vars_in_cex =
-        cex->get_per_var_info()->vars_noslice_in_cex;
+        cex->get_varset_unslice();
 
       for (const auto & p : loaded_predicates_) {
         smt::UnorderedTermSet vars_in_pred;
@@ -73,7 +152,7 @@ unsigned IC3ng::extend_predicates(Model *cex, smt::TermVec & conj_inout) {
             var_info->preds_w_related_vars.push_back(p);
           }
         }
-      }
+      } // end of for each load_predicates_
       var_info->related_info_populated = true;
     }
 
@@ -81,35 +160,32 @@ unsigned IC3ng::extend_predicates(Model *cex, smt::TermVec & conj_inout) {
     smt::TermVec predicates_to_use;
     {
       solver_->push();
-      auto cex_formula = cex->to_expr(solver_);
-      solver_->assert_formula(cex_formula);
+      disable_all_labels();
+      solver_->assert_formula(cex->to_expr(solver_));
 
       // First check subset vars, double check
       for (const auto & p : var_info->preds_w_subset_vars) {
         // check p
-        smt::TermVec assumptions;
-        assumptions.push_back(p);
-        auto r1 = solver_->check_sat_assuming(assumptions);
-        if (r1.is_unsat()) {
+        auto r = solver_->check_sat_assuming({p});
+        if (r.is_unsat()) {
           predicates_to_use.push_back(smart_not(p));
           continue;
         }
         // check not(p)
-        assumptions.clear();
-        assumptions.push_back(smart_not(p));
-        auto r2 = solver_->check_sat_assuming(assumptions);
-        if (r2.is_unsat()) {
+        r = solver_->check_sat_assuming({smart_not(p)});
+        if (r.is_unsat()) {
           predicates_to_use.push_back(p);
         }
       }
 
+      // HZ: is this substitution really helpful?
       // always handle related vars, no matter how many subset vars found
-      const auto & vars_in_cex = cex->get_per_var_info()->vars_noslice_in_cex;
+      const auto & vars_in_cex = cex->get_varset_unslice();
       for (const auto & p : var_info->preds_w_related_vars) {
         // achieve the vars in p but not in cex
         smt::UnorderedTermSet vars_in_pred;
         smt::get_free_symbolic_consts(p, vars_in_pred);
-        smt::UnorderedTermSet external_vars;
+        smt::UnorderedTermSet external_vars; // external_vars = vars_in_pred - vars_in_cex
         for (const auto & v : vars_in_pred) {
           if (vars_in_cex.find(v) == vars_in_cex.end()) {
             external_vars.insert(v);
@@ -154,18 +230,14 @@ unsigned IC3ng::extend_predicates(Model *cex, smt::TermVec & conj_inout) {
               auto subst_p = subst_terms[0];  // We only substituted one term
               
               // Check the substituted predicate (bi-directional check)
-              smt::TermVec assumptions;
-              assumptions.push_back(subst_p);
-              auto r1 = solver_->check_sat_assuming(assumptions);
+              auto r1 = solver_->check_sat_assuming({subst_p});
               if (r1.is_unsat()) {
                 predicates_to_use.push_back(smart_not(subst_p));
                 found_useful = true;
                 break;
               }
               
-              assumptions.clear();
-              assumptions.push_back(smart_not(subst_p));
-              auto r2 = solver_->check_sat_assuming(assumptions);
+              auto r2 = solver_->check_sat_assuming({smart_not(subst_p)});
               if (r2.is_unsat()) {
                 predicates_to_use.push_back(subst_p);
                 found_useful = true;
@@ -191,9 +263,10 @@ unsigned IC3ng::extend_predicates(Model *cex, smt::TermVec & conj_inout) {
   auto num_preds = preds.size();
 
   if (num_preds == 0) {
+    // if we find no additional predicates, we will just return
     return 0;
   }
-
+  // conj_inout := VectorConcat(preds, conj_inout)
   preds.insert(preds.end(), conj_inout.begin(), conj_inout.end());
   conj_inout.swap(preds);
 
@@ -201,7 +274,7 @@ unsigned IC3ng::extend_predicates(Model *cex, smt::TermVec & conj_inout) {
   std::cout << "\n=== Extended Predicates Analysis ===\n";
   
   // Print variables in cex
-  const auto & vars_in_cex = cex->get_per_var_info()->vars_noslice_in_cex;
+  const auto & vars_in_cex = cex->get_varset_unslice();
   std::cout << "Variables in counterexample:\n";
   for (const auto & v : vars_in_cex) {
     std::cout << "  " << v->to_string() << " [sort: " << v->get_sort()->to_string() << "]\n";

--- a/engines/ic3ng-support/support.cpp
+++ b/engines/ic3ng-support/support.cpp
@@ -13,31 +13,6 @@ bool IC3ng::can_sat(const smt::Term & t) {
   return res.is_sat();
 }
 
-void IC3ng::cut_vars_curr(std::unordered_map<smt::Term,std::vector<std::pair<int,int>>> & v, bool cut_curr_input) {
-  auto pos = v.begin();
-  if (!cut_curr_input) { // then we only cut next input
-    while(pos != v.end()) {
-      // if has assumption
-      // will not remove input var
-      if(!ts_.is_curr_var(pos->first)) {
-        // assert it must be an input var
-        assert(no_next_vars_nxt_.find(pos->first) != no_next_vars_nxt_.end());
-        pos = v.erase(pos);
-      } else
-        ++pos;
-    }
-  } else { // if no assumption, will not keep input, erase everything but current var
-    while(pos != v.end()) {
-      if (actual_statevars_.find(pos->first) == actual_statevars_.end()) {
-        // if it is not a state variable, then remove
-        assert(no_next_vars_.find(pos->first) != no_next_vars_.end() ||
-               no_next_vars_nxt_.find(pos->first) != no_next_vars_nxt_.end());
-        pos = v.erase(pos);
-      } else
-        ++pos;
-    }
-  } // else : no assumption
-} // end of cut_vars_curr
 
 
 
@@ -204,6 +179,16 @@ void IC3ng::sanity_check_cex_is_correct(fcex_t * cex_at_cycle_0) {
   solver_->pop();
 } // end of sanity_check_cex_is_correct
 
+void IC3ng::disable_all_labels() {
+  for (unsigned idx = 0; idx < frame_labels_.size(); ++idx)
+    solver_->assert_formula(smart_not(frame_labels_.at(idx)));
+}
+
+void IC3ng::assert_init() {
+  solver_->assert_formula(init_label_);
+  for (unsigned idx = 1; idx < frame_labels_.size(); ++idx)
+    solver_->assert_formula(smart_not(frame_labels_.at(idx)));
+}
 
 void IC3ng::assert_frame(unsigned fidx) {
   assert(fidx < frame_labels_.size());

--- a/engines/ic3ng.cpp
+++ b/engines/ic3ng.cpp
@@ -1,5 +1,5 @@
 /*********************                                                  */
-/*! \file ic3bits.cpp
+/*! \file ic3ng.cpp
 ** \verbatim
 ** Top contributors (to current version):
 **   Hongce Zhang
@@ -28,11 +28,11 @@ namespace pono
 IC3ng::IC3ng(const Property & p, const TransitionSystem & ts,
             const smt::SmtSolver & s,
             PonoOptions opt) :
-  Prover(p, ts, s, opt), 
+  Prover(p, ts, s, opt)
 #ifdef DEBUG_IC3
-  // debug_fout("debug.smt2"),
+  // , debug_fout("debug.smt2")
 #endif
-  partial_model_getter(s)
+  // partial_model_getter(s)  // removing partial model, we now use unsatcore-based method
   // bitwuzla can accept non-literal to reduce anyway
   {     
     initialize();
@@ -85,6 +85,13 @@ void IC3ng::initialize() {
 
   boolsort_ = solver_->make_sort(smt::BOOL);
   solver_true_ = solver_->make_term(true);
+  solver_false_ = solver_->make_term(false);
+
+  bv1_sort_ = solver_->make_sort(smt::BV, 1);
+  solver_1_1 = solver_->make_term(1, bv1_sort_);
+  solver_0_1 = solver_->make_term(0, bv1_sort_);;
+
+
   Prover::initialize();
   check_ts();
 
@@ -103,26 +110,23 @@ void IC3ng::initialize() {
       nxt_state_updates_.emplace(ts_.next(sv), s_updates.at(sv));
   }
 
-  has_assumptions = false;
+  has_assumptions = !ts_.constraints().empty();
   assert(!nxt_state_updates_.empty());
 
   for (const auto & c_initnext : ts_.constraints()) {
     // if (!c_initnext.second)
     //  continue; // should not matter
-    has_assumptions = true;
     assert(ts_.no_next(c_initnext.first));
     // if (no_next) {
     constraints_curr_var_.push_back(c_initnext.first);
-    vars_in_constraints_.push_back({});
-    smt::get_free_symbolic_consts(constraints_curr_var_.back(), vars_in_constraints_.back());
+    smt::get_free_symbolic_consts(constraints_curr_var_.back(), vars_in_constraints_);
 
     // translate input_var to next input_var
     // but the state var ...
     // we will get to next anyway
     constraints_curr_var_.push_back(
       next_trans_replace(ts_.next(c_initnext.first)));
-    vars_in_constraints_.push_back({});
-    smt::get_free_symbolic_consts(constraints_curr_var_.back(), vars_in_constraints_.back());
+    smt::get_free_symbolic_consts(constraints_curr_var_.back(), vars_in_constraints_);
     // } // else skip
   }
   all_constraints_ = has_assumptions ? smart_and(constraints_curr_var_) : solver_true_;
@@ -211,7 +215,16 @@ ic3_rel_ind_check_result IC3ng::rel_ind_check( unsigned prevFidx,
   //  c = a /\ b
   // predecessor generalization is implemented through partial model
   // not good enough
-  std::unordered_map<smt::Term,std::vector<std::pair<int,int>>> varlist_slice;
+  smt::UnorderedTermSet sliced_varset;
+  smt::UnorderedTermSet unsliced_varset;
+  smt::TermVec eqs;
+  // use unsatcore reduction
+
+  // solver_->pop(); is called in `get_min_pred`
+  get_min_pred(bad_next_to_assert, 
+    prevFidx, sliced_varset, unsliced_varset, eqs);
+
+#if 0  // HZ:removing partial-model-based method
   std::unordered_map<smt::Term,std::vector<std::pair<int,int>>> input_asts_slices = {
     {bad_next_to_assert, { {0,0} }}
   };
@@ -250,15 +263,14 @@ ic3_rel_ind_check_result IC3ng::rel_ind_check( unsigned prevFidx,
   } // end of has assumption
 
   partial_model_getter.GetVarListForAsts_in_bitlevel(input_asts_slices, varlist_slice);
+#endif
   // after this step varlist_slice may contain 
   // 1. current state var , 2. current input var
   // 3. next input var (it should not contain next state var)
   // if there is no assumption, we can remove 2&3
   // if there is assumption, we can only remove 3
   
-  cut_vars_curr(varlist_slice, !has_assumptions); // // if we don't have assumptions we can cut current input
-  Model * prev_ex = new_model(varlist_slice);
-  solver_->pop();
+  Model * prev_ex = new_model(std::move(sliced_varset), std::move(unsliced_varset), std::move(eqs)); // just move to avoid copy
 
   // must after pop
   //if(has_assumptions)
@@ -287,7 +299,7 @@ bool IC3ng::recursive_block_all_in_queue() {
   while(!proof_goals.empty()) {
     fcex_t * fcex = proof_goals.top();
 
-    D(2, "[recursive_block] Try to block {} @ F{}", (long long)(fcex), fcex->fidx);
+    D(2, "[recursive_block] Try to block {} @ F{}", (long long)(fcex->cex), fcex->fidx);
     D(3, "[recursive_block] Try to block {} @ F{}", fcex->cex->to_string(), fcex->fidx);
     // if we arrive at a new frame, eager push from prior frame
     if (fcex->fidx > prior_round_frame_no) {
@@ -297,8 +309,16 @@ bool IC3ng::recursive_block_all_in_queue() {
       D(2,"Eager push from {} --> {}", prior_round_frame_no, fcex->fidx);
     }
     prior_round_frame_no = fcex->fidx;
+    // HZ: TODO: add a syntactic check here!
+    bool trivial_block = false;
+    for (Lemma * l : frames.at(fcex->fidx)) {
+      if (l->cex() == fcex->cex) {
+        trivial_block = true;
+        break;
+      }
+    }
 
-    if (frame_implies(fcex->fidx, smart_not(fcex->cex->to_expr(solver_)))) {
+    if (trivial_block || frame_implies(fcex->fidx, smart_not(fcex->cex->to_expr(solver_)))) {
       proof_goals.pop();
       D(2, "[recursive_block] F{} -> not(cex)", fcex->fidx);
       continue;
@@ -318,7 +338,7 @@ bool IC3ng::recursive_block_all_in_queue() {
       // TODO make a lemma, to explain why F(i) /\ T => not MODEL
       
       D(2, "[recursive_block] Not reachable on F{}", fcex->fidx);
-      inductive_generalization(fcex->fidx-1, fcex->cex, fcex->cex_origin);
+      inductive_generalization_mic(fcex->fidx-1, fcex->cex, fcex->cex_origin);
       proof_goals.pop();
 
       if (lowest_frame_touched_ > fcex->fidx)
@@ -340,18 +360,6 @@ bool IC3ng::recursive_block_all_in_queue() {
 } // recursive_block_all_in_queue
 
 
-static size_t TermScore(const smt::Term & t) {
-  auto e = (t->get_op().prim_op == smt::PrimOp::Not ||
-            t->get_op().prim_op == smt::PrimOp::BVNot) ? *(t->begin()): t;
-  unsigned slice = 0;
-  if (e->get_op().prim_op == smt::PrimOp::Extract) {
-    slice = e->get_op().idx0;
-    auto c = *(e->begin());
-    slice += c->get_sort()->get_width();
-  }
-  return slice;
-}
-
 void IC3ng::dump_invariants(std::ostream & os) const {
     if (frames.empty()) {
         os << "No frames available.\n";
@@ -371,305 +379,9 @@ void IC3ng::dump_invariants(std::ostream & os) const {
     }
     
     D(1, "Finished dumping {} lemmas", last_frame.size());
-}
-
-static void SortLemma(smt::TermVec & inout, bool descending) {
-  // we don't want to sort the term themselves
-  // we don't want to invoke TermScore function more than once for a term
-  std::vector<std::pair<size_t,size_t>> complexity_index_pair;
-  size_t idx = 0;
-  for (const auto & t : inout) {
-    complexity_index_pair.push_back({ TermScore(t) ,idx});
-    ++ idx;
-  }
-
-  // HZ: it seems that descending sorting will put lower bits first
-  //       unegated first
-  //       negated second
-
-  //  0: ((_ extract 0 0) x)
-  //  1: ((_ extract 2 2) x)
-  // ....
-  // 10: (bvnot ((_ extract 1 1) x))
-#ifdef DEBUG_IC3
-  std::cout << "Before sorting:\n";
-  unsigned i = 0;
-  for (const auto & e : inout)
-    std::cout << " " << i++ << ": " << e->to_string() << "\n";
-  std::cout << "------------------\n";
-#endif
-
-  // sort in descending order (the `first` is compared first), so term-index with 
-  // the highest score will rank first
-  if(descending) // from greater to smaller
-    std::sort(complexity_index_pair.begin(), complexity_index_pair.end(), std::greater<>());
-  else // from smaller to greater
-    std::sort(complexity_index_pair.begin(), complexity_index_pair.end(), std::less<>());
-    
-
-  // now map back to termvec
-  smt::TermVec sorted_term;
-  for (const auto & cpl_idx_pair : complexity_index_pair) {
-    sorted_term.push_back(inout.at(cpl_idx_pair.second));
-  }
-  inout.swap(sorted_term); // this is the same as inout = sorted_term, but faster
+} // end of dump_invariants
 
 
-} // end of SortLemma
-
-// ( ( not(S) /\ F /\ T ) \/ init_prime ) /\ ( cube' )
-//   cube (v[0]=1 /\ v[1]=0 /\ ...)
-void IC3ng::inductive_generalization(unsigned fidx, Model *cex, LCexOrigin origin) {
-  auto F = get_frame_formula(fidx);
-  auto T = get_trans_for_vars(cex->get_varset_noslice());
-  auto F_and_T = smart_and<smt::TermVec>({F,T});
-
-  smt::TermVec conjs;
-  cex->to_expr_conj(solver_, conjs);
-
-  // Sort lemmas initially
-  SortLemma(conjs, options_.ic3base_sort_lemma_descending);
-
-  // length of conjs before extension
-  size_t npred_before_extension = conjs.size();
-
-  // Track original predicates before extension
-  smt::TermVec original_conjs = conjs;
-  auto npred = extend_predicates(cex, conjs);
-  size_t npred_after_extension = conjs.size();
-
-#ifdef DEBUG_IC3
-  std::cout << "Initial predicates after sorting:\n";
-  unsigned i = 0;
-  for (const auto & e : conjs)
-    std::cout << " " << i++ << ": " << e->to_string() << "\n";
-  std::cout << "------------------\n";
-#endif
-
-  // Track all found lemmas
-  std::vector<smt::Term> all_lemmas;
-  std::unordered_set<smt::Term> used_predicates;
-
-  // Multiple iterations to find high-quality lemmas
-  bool found_new_lemma = true;
-  int max_iterations = 3; // Limit iterations to prevent infinite loops
-  int iteration = 0;
-
-  while (found_new_lemma && iteration < max_iterations) {
-    found_new_lemma = false;
-    iteration++;
-
-    // Check if we've used all available predicates
-    if (used_predicates.size() >= (npred_after_extension - npred_before_extension)) {
-      D(2, "[ig] All loaded predicates have been used");
-      break;
-    }
-
-    // Filter out already used predicates
-    smt::TermVec current_conjs;
-    for (const auto & conj : conjs) {
-      if (used_predicates.find(conj) == used_predicates.end()) {
-        current_conjs.push_back(conj);
-      }
-    }
-
-    if (current_conjs.empty()) {
-      D(2, "[ig] Iteration {} - No more unused predicates", iteration);
-      break;
-    }
-
-#ifdef DEBUG_IC3
-    std::cout << "Iteration " << iteration << " available predicates:\n";
-    i = 0;
-    for (const auto & e : current_conjs)
-      std::cout << " " << i++ << ": " << e->to_string() << "\n";
-    std::cout << "------------------\n";
-#endif
-
-    D(2, "[ig] Iteration {} with {} predicates", iteration, current_conjs.size());
-
-    auto cex_expr = smart_not(smart_and(current_conjs));
-
-    if (current_conjs.size() > 1) {
-      smt::TermList conjs_nxt;
-      std::unordered_map<smt::Term, size_t> conjnxt_to_idx_map;
-      size_t old_size = current_conjs.size();
-      
-      for (size_t idx = 0; idx < old_size; ++idx) {
-        conjs_nxt.push_back(ts_.next(current_conjs.at(idx)));
-        conjnxt_to_idx_map.emplace(conjs_nxt.back(), idx);
-      }
-
-      smt::Term base = smart_or<smt::TermVec>(
-        {smart_and<smt::TermVec>({cex_expr, F_and_T}), init_prime_});
-
-      solver_->push();
-      syntax_analysis::reduce_unsat_core_to_fixedpoint(base, conjs_nxt, solver_);
-      solver_->pop();
-      D(2, "[ig] core size: {} => {}", old_size, conjs_nxt.size());
-
-      smt::TermList conjs_list;
-      for (const auto & c : conjs_nxt) {
-        auto orig_conj = current_conjs.at(conjnxt_to_idx_map.at(c));
-        conjs_list.push_back(orig_conj);
-        // Only add to used_predicates if it was from loaded predicates
-        if (std::find(loaded_predicates_.begin(), loaded_predicates_.end(), orig_conj) != loaded_predicates_.end()) {
-          used_predicates.insert(orig_conj);
-          std::cout << "Used predicate: " << orig_conj->to_string() << std::endl;
-        }
-      }
-
-      if (conjs_nxt.size() > 1) {
-        solver_->push();
-        reduce_unsat_core_linear_backwards(F_and_T, conjs_list, conjs_nxt);
-        solver_->pop();
-      }
-
-#ifdef DEBUG_IC3
-      std::cout << "Iteration " << iteration << " kept predicates:\n";
-      for (const auto & e : conjs_list) {
-        std::cout << "  " << e->to_string() << "\n";
-      }
-      std::cout << "------------------\n";
-#endif
-
-      if (!conjs_list.empty()) {
-        auto new_lemma = smart_not(smart_and(conjs_list));
-        all_lemmas.push_back(new_lemma);
-        found_new_lemma = true;
-        D(3, "[ig] Found new lemma in iteration {}: {}", iteration, new_lemma->to_string());
-      }
-    }
-  }
-
-  D(1, "[ig] F{} found {} lemmas in {} iterations", fidx+1, all_lemmas.size(), iteration);
-
-  // Add all found lemmas to the frame
-  for (const auto & lemma : all_lemmas) {
-    D(3, "[ig] F{} adding lemma: {}", fidx+1, lemma->to_string());
-    add_lemma_to_frame(new_lemma(lemma, cex, origin), fidx+1);
-  }
-
-  // If no lemmas found, add the original one
-  if (all_lemmas.empty()) {
-    auto cex_expr = smart_not(smart_and(conjs));
-    D(3, "[ig] F{} adding fallback lemma: {}", fidx+1, cex_expr->to_string());
-    add_lemma_to_frame(new_lemma(cex_expr, cex, origin), fidx+1);
-  }
-}
-
-// a helper function : the rev version
-// it goes from the end to the beginning
-void remove_and_move_to_next_backward(smt::TermList & pred_set_prev, 
-  smt::TermList::iterator & pred_pos_rev,
-  smt::TermList & pred_set, 
-  smt::TermList::iterator & pred_pos,
-  const smt::UnorderedTermSet & unsatcore) {
-
-  assert(pred_set.size() == pred_set_prev.size());
-  assert(pred_pos != pred_set.end());
-  assert(pred_pos_rev != pred_set_prev.end());
-
-  // Store the target term value
-  auto target_term = *pred_pos;
-  
-  auto pred_iter = pred_set.end();
-  auto pred_iter_prev = pred_set_prev.end();
-
-  bool reached = false;
-  bool next_pos_found = false;
-  smt::TermList::iterator next_pos, next_pos_prev;
-
-  while(pred_iter != pred_set.begin()) {
-    --pred_iter;
-    --pred_iter_prev;
-    
-    // Compare values instead of iterators
-    if (!reached && *pred_iter == target_term) {
-      reached = true;
-    }
-    
-    if (unsatcore.find(*pred_iter) == unsatcore.end()) {
-      pred_iter = pred_set.erase(pred_iter);
-      pred_iter_prev = pred_set_prev.erase(pred_iter_prev);
-    } else {
-      if (reached && !next_pos_found) {
-        next_pos = pred_iter;
-        next_pos_prev = pred_iter_prev;
-        next_pos_found = true;
-      }
-    }
-  }
-
-  // Handle the first element if needed
-  if (!reached && *pred_iter == target_term) {
-    reached = true;
-  }
-
-  if (!next_pos_found && reached) {
-    if (unsatcore.find(*pred_iter) != unsatcore.end()) {
-      next_pos = pred_iter;
-      next_pos_prev = pred_iter_prev;
-      next_pos_found = true;
-    }
-  }
-
-  assert(reached); // This should now be safe
-
-  if (next_pos_found) {
-    pred_pos = ++next_pos;
-    pred_pos_rev = ++next_pos_prev;
-  } else {
-    pred_pos = pred_set.begin();
-    pred_pos_rev = pred_set_prev.begin();
-  }
-}
-
-// 1. check if init /\ (conjs-removed)  is unsat
-// 2. if so, check ( ( not(conjs-removed) /\ F /\ T ) /\ ( conjs-removed )' is unsat?
-void IC3ng::reduce_unsat_core_linear_backwards(const smt::Term & F_and_T,
-  smt::TermList &conjs, smt::TermList & conjs_nxt) {
-  
-  auto to_remove_pos_prev = conjs.end();
-  auto to_remove_pos_next = conjs_nxt.end();
-
-  assert(conjs.size() == conjs_nxt.size());
-
-  while(to_remove_pos_prev != conjs.begin()) {
-    to_remove_pos_prev--; // firstly, point to the last one
-    to_remove_pos_next--;
-
-    if (conjs.size() == 1)
-      continue;
-
-    smt::Term term_to_remove = *to_remove_pos_prev;
-    smt::Term term_to_remove_next = *to_remove_pos_next;
-
-    auto pos_after_conj = conjs.erase(to_remove_pos_prev);
-    auto pos_after_conj_nxt = conjs_nxt.erase(to_remove_pos_next);
-
-
-    auto cex_expr = smart_not(smart_and(conjs));
-    auto base = smart_or<smt::TermVec>(
-        { smart_and<smt::TermVec>(  {cex_expr, F_and_T} ) , init_prime_ } );
-
-    solver_->push();
-    solver_->assert_formula(base);
-    smt::Result r = solver_->check_sat_assuming_list(conjs_nxt);
-
-    to_remove_pos_prev = conjs.insert(pos_after_conj, term_to_remove);
-    to_remove_pos_next = conjs_nxt.insert(pos_after_conj_nxt, term_to_remove_next);
-    if (r.is_sat()) {
-      solver_->pop();
-      continue;
-    } // else { // if unsat, we can remove
-    smt::UnorderedTermSet core_set;
-    solver_->get_unsat_assumptions(core_set);
-    // below function will update assumption_list and to_remove_pos
-    remove_and_move_to_next_backward(conjs, to_remove_pos_prev, conjs_nxt, to_remove_pos_next, core_set);
-    solver_->pop();
-  } // end of while
-}
 
 
 ProverResult IC3ng::step(int i)

--- a/engines/ic3ng.h
+++ b/engines/ic3ng.h
@@ -62,17 +62,18 @@ namespace pono
     smt::SmtSolver & solver() override { return solver_; }
     std::string print_frame_stat() const ;
     void print_time_stat(std::ostream & os) const;
-
+    
+    // set up helper predicates 
     void virtual set_helper_term_predicates(const smt::TermVec & ) override;
+    // give the clauses that will appear in F1
+    // will run the check: init -> c    and   init /\ T -> c'
+    void virtual set_helper_term_clauses(const smt::TermVec & clauses) override;
+    
     void dump_invariants(std::ostream & os) const;
 
   protected:
     std::ofstream debug_fout;
     bool has_assumptions;
-    // this is used to cut input
-    void cut_vars_curr(std::unordered_map<smt::Term,std::vector<std::pair<int,int>>> & v, bool cut_curr_input);
-
-    PartialModelGen partial_model_getter;
 
     // will only keep those not pushed yet
     std::vector<frame_t> frames;
@@ -84,8 +85,12 @@ namespace pono
     smt::TermVec frame_labels_;  ///< labels to activate frames
     // useful terms
     smt::Term solver_true_;
+    smt::Term solver_false_;
+    smt::Term solver_1_1;
+    smt::Term solver_0_1;
 
     smt::Sort boolsort_;
+    smt::Sort bv1_sort_;
 
     virtual void check_ts();
     smt::Term get_trans_for_vars(const smt::UnorderedTermSet & vars);
@@ -98,7 +103,7 @@ namespace pono
     smt::UnorderedTermSet no_next_vars_nxt_; //  the next state of inputs
     
     smt::TermVec constraints_curr_var_;
-    std::vector<smt::UnorderedTermSet>  vars_in_constraints_;
+    smt::UnorderedTermSet  vars_in_constraints_; // pre-computed by initialize
     smt::Term all_constraints_; // all constraints
     smt::Term init_prime_;
     smt::UnorderedTermMap nxt_state_updates_; // a map from prime var -> next
@@ -116,6 +121,8 @@ namespace pono
     void add_lemma_to_frame(Lemma * lemma, unsigned fidx);
 
     // will also cancel out other frame labels
+    void disable_all_labels();
+    void assert_init();
     void assert_frame(unsigned fidx);
     bool frame_implies(unsigned fidx, const smt::Term & expr);
 
@@ -135,6 +142,21 @@ namespace pono
     void reduce_unsat_core_linear_backwards(const smt::Term & F_and_T,
       smt::TermList &conjs, smt::TermList & conjs_nxt);
 
+    // an implementation following the general ic3-mic method, let's see how it works?
+    bool ic3_down(smt::TermList & conjs_list, smt::TermList & conjs_next, 
+      const smt::Term & Trans, unsigned fidx,
+      std::unordered_map<smt::Term, size_t> & conjnxt_to_idx_map, smt::TermVec all_conjs_curr);
+    void inductive_generalization_mic(unsigned fidx, Model *cex, LCexOrigin origin);
+    
+    void SortCube(std::vector<std::pair<smt::Term, smt::Term>> & inout, bool descending);
+    // reduce predecessor by unsat core reduction
+    void get_min_pred(
+      const smt::Term &bad_next, /* bad (over current version of variables) */
+      unsigned prevFidx, // fidx
+      smt::UnorderedTermSet & slicedvars,
+      smt::UnorderedTermSet & noslicevars,
+      smt::TermVec & eqs);
+
     // \neg C /\ F /\ C
     //           F /\ p
     ic3_rel_ind_check_result rel_ind_check( unsigned prevFidx, 
@@ -144,8 +166,14 @@ namespace pono
     
     // return value: the predicates added
     unsigned extend_predicates(Model *cex, smt::TermVec & conj_inout);
+    void sort_pred_in_extend_predicates(smt::TermVec &);
     smt::TermVec loaded_predicates_;
     std::unordered_map<Model *, PerCexInfo> model_info_map_;
+
+    // Store side-loaded clauses for first frame
+    smt::TermList loaded_clauses_;
+    // Add method declaration
+    //void process_external_clauses(const std::string & filename);
 
     /**
      * misc functions, supportive functions
@@ -183,7 +211,46 @@ namespace pono
       }
       return term;
     }
-    
+
+  smt::Term bv_to_bool(const smt::Term & t) {
+    smt::Sort sort = t->get_sort();
+    if (sort->get_sort_kind() == smt::BV) {
+      if (sort->get_width() != 1) {
+        throw PonoException("Can't convert non-width 1 bitvector to bool.");
+      }
+      return solver_->make_term(
+        smt::Equal, t, solver_->make_term(1, solver_->make_sort(smt::BV, 1)));
+    } else {
+      return t;
+    }
+  }
+
+
+    // a simple helper function
+    bool extract_bit_from_val(const smt::Term & val) const {
+      if (val == solver_true_)
+        return true;
+      if (val == solver_false_)
+        return false;
+      if (val == solver_0_1)
+        return false;
+      if (val == solver_1_1)
+        return true;
+      if (val->get_op().prim_op == smt::Extract) {
+        auto slice = val->get_op().idx0;
+        assert(slice == val->get_op().idx1);
+        auto internal_val = *(val->begin());
+        assert(internal_val->is_value());
+        auto strval = internal_val->to_string();
+        auto ch = strval.at(strval.length()-1-slice);
+        assert(ch == '0' || ch == '1');
+        return (ch == '0');
+      }
+      assert(false); // not handled
+    }
+
+    bool extract_neg_from_val(const smt::Term & t) const { return extract_bit_from_val(t) == false; }
+
   }; // end of class IC3ng
 
 } // namespace pono

--- a/engines/prover.h
+++ b/engines/prover.h
@@ -67,6 +67,7 @@ class Prover
   smt::Term invar();
 
   void virtual set_helper_term_predicates(const smt::TermVec & ) {}
+  void virtual set_helper_term_clauses(const smt::TermVec & ) {}
 
  protected:
   /** Take a term from the Prover's solver

--- a/frontends/external_term.cpp
+++ b/frontends/external_term.cpp
@@ -30,12 +30,17 @@ ExternalTermInterface::ExternalTermInterface(const std::string & filename, Trans
   assert(!res);  // 0 means success
 
   for(const auto & n_prop : defs_){
-      if(n_prop.first.find("assertion.") == 0)
+      // for proving aids
+      if(n_prop.first.find("assertion.") == 0) // augmenting assertions
         assertions_.push_back(n_prop.second);
-      if(n_prop.first.find("assumption.") == 0)
-        assumptions_.push_back(n_prop.second);
       if(n_prop.first.find("predicate.") == 0)
         predicates_.push_back(n_prop.second);
+      if(n_prop.first.find("f1clause.") == 0)
+        clauses_.push_back(n_prop.second);
+      
+      // For augmenting transition systems
+      if(n_prop.first.find("assumption.") == 0)
+        assumptions_.push_back(n_prop.second);
   }
 }
 

--- a/frontends/external_term.h
+++ b/frontends/external_term.h
@@ -38,6 +38,8 @@ class ExternalTermInterface : public smt::SmtLibReader
 
   void AddAssumptionsToTS();
   const smt::TermVec & GetExternalPredicates() const { return predicates_; }
+  const smt::TermVec & GetAugmentingAssertions() const { return assertions_; }
+  const smt::TermVec & GetF1LemmaCandidates() const { return clauses_; }
 
  protected:
   // overloaded function, used when arg list of function is parsed
@@ -51,7 +53,7 @@ class ExternalTermInterface : public smt::SmtLibReader
   smt::TermVec predicates_;
   smt::TermVec assertions_;
   smt::TermVec assumptions_;
-
+  smt::TermVec clauses_;    // the sideloaded clauses to be put on F1
 };
 
 }  // namespace pono

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -76,6 +76,8 @@ enum optionIndex
   SYGUS_TERM_MODE,
   IC3SA_INITIAL_TERMS_LVL,
   IC3SA_INTERP,
+  IC3NG_ALWAYS_MULTILEMMA,
+  IC3NG_MULTILEMMA_NUM,
   PRINT_WALL_TIME,
   BMC_BOUND_START,
   BMC_BOUND_STEP,
@@ -460,6 +462,20 @@ const option::Descriptor usage[] = {
     Arg::None,
     "  --ic3sa-interp \tuse interpolants to find more terms during refinement "
     "(default: off)" },
+  { IC3NG_ALWAYS_MULTILEMMA,
+    0,
+    "",
+    "ic3ng-always-multi-lemma",
+    Arg::None,
+    "  --ic3ng-always-multi-lemma \twhether always generate multiple lemmas"
+    "(default: only when predicates are used)" },
+  { IC3NG_MULTILEMMA_NUM,
+    0,
+    "",
+    "ic3ng-multi-lemma-num",
+    Arg::Numeric,
+    "  --ic3ng-multi-lemma-num \tNumber of lemmas to generate"
+    "(default: 3)" },
     { PRINT_WALL_TIME,
     0,
     "",
@@ -776,6 +792,8 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           break;
         }
         case IC3SA_INTERP: ic3sa_interp_ = true; break;
+        case IC3NG_ALWAYS_MULTILEMMA: ic3ng_indgen_multilemma_on_predicates_only = false; break;
+        case IC3NG_MULTILEMMA_NUM: ic3ng_indgen_max_round = atoi(opt.arg); break;
         case PRINT_WALL_TIME: print_wall_time_ = true; break;
         case BMC_BOUND_START: bmc_bound_start_ = atoi(opt.arg); break;  
         case BMC_BOUND_STEP: bmc_bound_step_ = atoi(opt.arg);

--- a/options/options.h
+++ b/options/options.h
@@ -113,6 +113,8 @@ class PonoOptions
         ic3ia_reduce_preds_(default_ic3ia_reduce_preds_),
         ic3ia_track_important_vars_(default_ic3ia_track_important_vars_),
         ic3sa_func_refine_(default_ic3sa_func_refine_),
+        ic3ng_indgen_multilemma_on_predicates_only(default_ic3ng_indgen_multilemma_on_predicates_only),
+        ic3ng_indgen_max_round(default_ic3ng_indgen_max_round),
         profiling_log_filename_(default_profiling_log_filename_),
         pseudo_init_prop_(default_pseudo_init_prop_),
         assume_prop_(default_assume_prop_),
@@ -212,6 +214,9 @@ class PonoOptions
   bool ic3ia_track_important_vars_;  ///< prioritize predicates with marked
                                      ///< important variables
   bool ic3sa_func_refine_;  ///< try functional unrolling in refinement
+  bool ic3ng_indgen_multilemma_on_predicates_only; ///< should we always try to indgen for multiple lemmas?
+                                                   ///or just when we have multiple predicates
+  unsigned int ic3ng_indgen_max_round; ///< max number of lemmas to try. default 3
   std::string profiling_log_filename_;
   bool pseudo_init_prop_;  ///< replace init and prop with boolean state vars
   bool assume_prop_;       ///< assume property in pre-state
@@ -328,6 +333,8 @@ private:
   static const bool default_ic3ia_reduce_preds_ = true;
   static const bool default_ic3ia_track_important_vars_ = true;
   static const bool default_ic3sa_func_refine_ = true;
+  static const bool default_ic3ng_indgen_multilemma_on_predicates_only = true;
+  static const unsigned int default_ic3ng_indgen_max_round = 3;
   static const std::string default_profiling_log_filename_;
   static const bool default_pseudo_init_prop_ = false;
   static const bool default_assume_prop_ = false;

--- a/pono.cpp
+++ b/pono.cpp
@@ -56,7 +56,9 @@ ProverResult check_prop(PonoOptions pono_options,
                         TransitionSystem & ts,
                         const SmtSolver & s,
                         std::vector<UnorderedTermMap> & cex,
-                        const TermVec & external_preds)
+                        const TermVec & external_preds,
+                        const TermVec & augmenting_assertions,
+                        const TermVec & f1_lemma_candidates)                        
 {
   // get property name before it is rewritten
   const string prop_name = ts.get_name(prop);
@@ -138,6 +140,9 @@ ProverResult check_prop(PonoOptions pono_options,
   assert(prover);
 
   prover->set_helper_term_predicates(external_preds);
+  prover->set_helper_term_clauses(f1_lemma_candidates);  // Use validated clauses
+  if (!augmenting_assertions.empty())
+    throw PonoException("Augmented assertion not implemented. Future work.");
 
   // TODO: handle this in a more elegant way in the future
   //       consider calling prover for CegProphecyArrays (so that underlying
@@ -300,12 +305,19 @@ int main(int argc, char ** argv)
             + pono_options.filename_ + " (" + to_string(num_props) + ")");
       }
 
-      TermVec external_predicates;
+      // ----------------------Load external predicates------------------------------
+      TermVec external_predicates, augmenting_assertions, f1_lemma_candidates;
       if (!pono_options.external_predicates_file_.empty()) {
         ExternalTermInterface term_if(pono_options.external_predicates_file_, fts);
         external_predicates = term_if.GetExternalPredicates();
+        augmenting_assertions = term_if.GetAugmentingAssertions();
+        f1_lemma_candidates = term_if.GetF1LemmaCandidates();
+
         // TODO add helper assertions/assumptions
-        std::cout << "Loaded " << external_predicates.size() << " predicates\n";
+        std::cout << "Loaded " << external_predicates.size() << " predicates, "
+                               << augmenting_assertions.size() << " assertions, "
+                               << f1_lemma_candidates.size() << " lemmas\n";
+
         unsigned i=0;
         for (const auto & p : external_predicates)
           std::cout << i++ <<" : " << p->to_string() << std::endl;
@@ -314,7 +326,8 @@ int main(int argc, char ** argv)
       Term prop = propvec[pono_options.prop_idx_];
 
       vector<UnorderedTermMap> cex;
-      res = check_prop(pono_options, prop, fts, s, cex, external_predicates);
+      res = check_prop(pono_options, prop, fts, s, cex, 
+              external_predicates, augmenting_assertions, f1_lemma_candidates);
       // we assume that a prover never returns 'ERROR'
       assert(res != ERROR);
 
@@ -363,7 +376,7 @@ int main(int argc, char ** argv)
       // get property name before it is rewritten
 
       std::vector<UnorderedTermMap> cex;
-      res = check_prop(pono_options, prop, rts, s, cex, {});
+      res = check_prop(pono_options, prop, rts, s, cex, {}, {}, {});
       // we assume that a prover never returns 'ERROR'
       assert(res != ERROR);
 
@@ -427,7 +440,7 @@ int main(int argc, char ** argv)
   if (pono_options.print_wall_time_) {
     auto end_time_stamp = timestamp();
     auto elapsed_time = timestamp_diff(begin_time_stamp, end_time_stamp);
-    std:cout << "Pono wall clock time (s): " <<
+    std::cout << "Pono wall clock time (s): " <<
       time_duration_to_sec_string(elapsed_time) << std::endl;
   }
 

--- a/utils/sygus_ic3formula_helper.cpp
+++ b/utils/sygus_ic3formula_helper.cpp
@@ -84,7 +84,7 @@ void IC3FormulaModel::get_varset(std::unordered_set<smt::Term> & varset) const {
   }
 }
 
-void reduce_unsat_core_to_fixedpoint(
+bool reduce_unsat_core_to_fixedpoint(
   const smt::Term & formula,
   smt::TermList & core_inout,
   const smt::SmtSolver & reducer_) {
@@ -93,21 +93,30 @@ void reduce_unsat_core_to_fixedpoint(
 
   // exit if the formula is unsat without assumptions.
   smt::Result r = reducer_->check_sat();
-  if (r.is_unsat())
-    return;
+  if (r.is_unsat()) {
+    core_inout.clear();
+    return true;
+  }
 
+  bool first_round = true;
   while(true) {
     r = reducer_->check_sat_assuming_list(core_inout);
-    assert(r.is_unsat());
+    if (r.is_sat()) {
+      assert(first_round);
+      return false;
+    }
+    first_round = false;
 
     smt::TermList core_out;
     reducer_->get_unsat_assumptions(core_out);
     if (core_inout.size() == core_out.size()) {
-      break; // fixed point is reached
+      return true; // fixed point is reached
     }
     assert(core_out.size() < core_inout.size());
     core_inout.swap(core_out);  // namely, core_inout = core_out,  but no need to copy
   }
+  assert(false); // should not reach this point
+  return true;
 }
 
 void reduce_unsat_core_to_fixedpoint(
@@ -119,8 +128,10 @@ void reduce_unsat_core_to_fixedpoint(
 
   // exit if the formula is unsat without assumptions.
   smt::Result r = reducer_->check_sat();
-  if (r.is_unsat())
+  if (r.is_unsat()) {
+    core_inout.clear();
     return;
+  }
 
   while(true) {
     r = reducer_->check_sat_assuming_set(core_inout);
@@ -258,8 +269,10 @@ void reduce_unsat_core_linear_rev(
 
   // exit if the formula is unsat without assumptions.
   smt::Result r = reducer_->check_sat();
-  if (r.is_unsat())
+  if (r.is_unsat()) {
+    assumption_list.clear();
     return;
+  }
 
   r = reducer_->check_sat_assuming_list(assumption_list);
   assert(r.is_unsat());

--- a/utils/sygus_ic3formula_helper.h
+++ b/utils/sygus_ic3formula_helper.h
@@ -64,7 +64,9 @@ void reduce_unsat_core_to_fixedpoint(const smt::Term & formula, smt::UnorderedTe
 void reduce_unsat_core_linear(const smt::Term & formula, smt::TermList & assumption_list, const smt::SmtSolver & solver_);
 
 
-void reduce_unsat_core_to_fixedpoint(const smt::Term & formula, smt::TermList & core_inout, const smt::SmtSolver & solver_);
+// return true, if succeed
+// return false, if it is not unsat
+bool reduce_unsat_core_to_fixedpoint(const smt::Term & formula, smt::TermList & core_inout, const smt::SmtSolver & solver_);
 // The rev version assumes that assumption_list are ordered as following:
 // [keep...remove]  (those we want to keep are put the first)
 void reduce_unsat_core_linear_rev(const smt::Term & formula, smt::TermList & assumption_list, const smt::SmtSolver & solver_);


### PR DESCRIPTION
(This is for our discussion on May 29)

- predgen is using unsat-core (instead of partial model)
- indgen is using mic (However indgen only supports 1 round for now)
- also add F1 clause interface
- now there are the sliced_var_info and unsliced_var_info  (cex is pointing to sliced_var_info and sliced_var_info is pointing to unsliced_var_info)

All the above come from the update in eda2contest branch

## Summary by Sourcery

Enhance the IC3ng engine by replacing partial-model generalization with an unsat-core-based predgen, adding a MIC-based inductive generalizer, supporting side-loaded F₁ clauses via a new interface, and refactoring model storage to use sliced/unsliced var info.

New Features:
- Add F1 clause interface to validate and side-load inductive clauses into frame F₁
- Use unsat-core-based method for predecessor generalization instead of partial-model
- Introduce MIC-based inductive generalization engine (indgen) supporting multi-lemma generation

Enhancements:
- Replace per-bit var-info maps with sliced/unsliced var info structures for model cubes
- Simplify model and lemma handling by storing cubes as equality lists
- Refactor IC3ng initialization and constraint handling, removing partial model getter
- Improve trivial-block detection and label management in recursive blocking

Build:
- Include new predgen.cpp and indgen.cpp in CMake build sources